### PR TITLE
Support recent Laravel packages

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -1,0 +1,46 @@
+---
+name: deploy staging
+
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup PHP 7.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: composer:v2
+
+      - uses: actions/checkout@v2
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Check platform requirements for composer
+        run: composer check-platform-reqs
+
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v2
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
+
+      - name: Install dependencies
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Run tests
+        run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
     }
   ],
   "require": {
-    "php": "^7.1.3",
-    "illuminate/support": "5.8.*|^6.0",
-    "graze/dog-statsd": "^0.4.1",
-    "moontoast/math": "^1.1"
+    "php": "^7.1|^8",
+    "illuminate/support": "5.8.*|^6|^7|^8",
+    "graze/dog-statsd": "^1.0",
+    "moontoast/math": "^1.2"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.1",
-    "orchestra/testbench": "^3.8"
+    "phpunit/phpunit": "^8.1|^8.5.8|^9.3.3",
+    "orchestra/testbench": "^3.8|^4|^5|^6"
   },
   "autoload": {
     "psr-4": {

--- a/config/dog-statsd.php
+++ b/config/dog-statsd.php
@@ -17,7 +17,7 @@ return [
 
         'server1' => [
             'host' => env('DOG_STATSD_SERVER1_HOST', '127.0.0.1'),
-            'port' => env('DOG_STATSD_SERVER1_PORT', 9125),
+            'port' => env('DOG_STATSD_SERVER1_PORT', 8125),
             'namespace' => 'laravel',
         ],
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,7 +13,7 @@
          verbose="true"
 >
     <testsuites>
-        <testsuite>
+        <testsuite name="All Tests">
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
@@ -23,6 +23,6 @@
         </whitelist>
     </filter>
     <php>
-        <env name="DB_CONNECTION" value="testing"/>
+        <env name="DB_CONNECTION" value="testing" force="true" />
     </php>
 </phpunit>


### PR DESCRIPTION
* Upgraded other dependencies where possible.
* Fixed the failing test - please check the config is now correct. I believe a default port of 8125 is intended and correct.
* Added a basic GitHub workflow file. It needs a test matrix for the various versions of PHP, Laravel, but this is a good start.